### PR TITLE
Updating make_epochs to current version of mne

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 *.fif
 *.easy
 *.info
+*.ini

--- a/demonstrations/synthesize_data/send_eeg_data.py
+++ b/demonstrations/synthesize_data/send_eeg_data.py
@@ -1,7 +1,6 @@
 """Example program to demonstrate how to send a multi-channel time series to
 LSL."""
 
-import random
 import time
 
 import numpy as np
@@ -9,20 +8,20 @@ import numpy as np
 from pylsl import StreamInfo, StreamOutlet
 
 # Our desired frequency.
-sfreq = 1 / 100.
+sfreq = 100.
 ch_names = [
     'Fp1','Fp2','AF3','AF4','F3','F4','F7','F8','FC5','FC6','T7','T8',
     'FC1','FC2','C3','C4','CP5','CP6','P7','P8','CP1','CP2','P3','P4','O1','O2',
     'PO3','PO4','Oz','Pz','Cz','Fz']
 n_chs = len(ch_names)
 
-info = StreamInfo('EEG_stream', 'EEG', len(ch_names), 100, 'float32',
+info = StreamInfo('EEG_stream', 'EEG', len(ch_names), sfreq, 'float32',
                   'uniqueID1234567890')
 
 # Manufacturer is not actually NeuroElectrics. We include this so that
 # rteeg.stream can identify and connect to this LabStreamingLayer stream.
 info.desc().append_child_value("manufacturer", "NeuroElectrics")
-info.desc().append_child_value("nominal_srate", "100")
+info.desc().append_child_value("nominal_srate", str(sfreq))
 for c in ch_names:
     info.desc().append_child("channel")\
         .append_child_value("name", c)\
@@ -38,9 +37,9 @@ f = 50
 i = 1
 while True:
     y = np.sin(2 * np.pi * f * i / Fs)
-    sample = [y for __ in xrange(n_chs)]
+    sample = [y for __ in range(n_chs)]
     noise = np.random.normal(0, 1, n_chs)
     sample = sample + noise
     outlet.push_sample(sample)
     i += 1
-    time.sleep(sfreq)
+    time.sleep(1/sfreq)

--- a/rteeg/stream.py
+++ b/rteeg/stream.py
@@ -75,9 +75,8 @@ def make_events(data, marker_stream, event_duration=0):
     lower_time_limit = data[-1, 0]
     upper_time_limit = data[-1, -1]
     # Copy markers into a Numpy ndarray.
-    tmp = np.array([row[:] for row in marker_stream.data
-                    if upper_time_limit >= row[-1] >= lower_time_limit],
-                   dtype=np.int32)
+    tmp = np.array([(marker_int, timestamp) for marker_int, timestamp in marker_stream.data
+                   if upper_time_limit >= timestamp >= lower_time_limit])
     # Pre-allocate array for speed.
     events = np.zeros(shape=(tmp.shape[0], 3), dtype=np.int32)
     # If there is at least one marker:
@@ -261,10 +260,10 @@ class EEGStream(BaseStream):
 
     def make_epochs(self, marker_stream, data_duration=None, events=None,
                     event_duration=0, event_id=None, apply_ica=True, tmin=-0.2,
-                    tmax=1.0, baseline=(None, 0), picks=None, name='Unknown',
+                    tmax=1.0, baseline=(None, 0), picks=None,
                     preload=False, reject=None, flat=None, proj=True, decim=1,
                     reject_tmin=None, reject_tmax=None, detrend=None,
-                    add_eeg_ref=None, on_missing='error',
+                    on_missing='error',
                     reject_by_annotation=True, verbose=None):
         """Create instance of mne.Epochs. If events are not supplied, this
         script must be connected to a Markers stream.
@@ -298,11 +297,11 @@ class EEGStream(BaseStream):
             raw = self.ica.apply(raw)
             # Should this be changed? ICA.apply() works in-place on raw.
         return Epochs(raw, events, event_id=event_id, tmin=tmin, tmax=tmax,
-                      baseline=baseline, picks=picks, name=name,
+                      baseline=baseline, picks=picks,
                       preload=preload, reject=reject, flat=flat, proj=proj,
                       decim=decim, reject_tmin=reject_tmin,
                       reject_tmax=reject_tmax, detrend=detrend,
-                      add_eeg_ref=add_eeg_ref, on_missing=on_missing,
+                      on_missing=on_missing,
                       reject_by_annotation=reject_by_annotation,
                       verbose=verbose)
 


### PR DESCRIPTION
In stream.py calling the `Epochs `function has been updated to the current version in mne-python.

The making of events from `marker stream` data has been made more explicit.

Minor changes have been made in the send_eeg_data.py demonstration file.